### PR TITLE
Fix for macOS + doubled titles

### DIFF
--- a/N2O.py
+++ b/N2O.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Created on Thu Jun 18 13:34:37 2020
+Created on Thu Aug 13 17:48:07 2023
 
-@author: books
+@author: books, arozx, jxpd
 """
 
 from os import makedirs, path
@@ -12,14 +12,23 @@ from zipfile import ZipFile
 from pathlib import Path
 import N2Omodule
 from tempfile import TemporaryDirectory
-from easygui import fileopenbox
+import argparse
 
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-i",
+    "--input",
+    default="notion.zip",
+    help="path to input zip file including .zip extension",
+)
+args = parser.parse_args()
 
-NotionZip = Path(fileopenbox(filetypes = ['*.zip']))
+NotionZip = args.input
+archiveName = args.input + "-ObsidianReady"
 
 
 # Load zip file
-notionsData = ZipFile(NotionZip, 'r')
+notionsData = ZipFile(NotionZip, "r")
 
 NotionPathRaw = []
 ObsidianPathRaw = []
@@ -27,18 +36,20 @@ NotionPaths = []
 ObsidianPaths = []
 
 
-
 # Generate a list of file paths for all zip content
 [NotionPathRaw.append(line.rstrip()) for line in notionsData.namelist()]
 
 verbose = False
+
+
 def debug_print(msg):
     if verbose:
         print(msg)
 
+
 # Clean paths for Obsidian destination
 regexUID = compile("\s+\w{32}")
-regexForbitCharacter = compile("[<>?:/\|*\"]")
+regexForbitCharacter = compile('[<>?:/\|*"]')
 
 for line in NotionPathRaw:
     ObsidianPathRaw.append(regexUID.sub("", line))
@@ -49,14 +60,15 @@ for line in NotionPathRaw:
 [ObsidianPaths.append(Path(line)) for line in ObsidianPathRaw]
 
 
-
 # Get all the relevant indices (folders, .md, .csv, others)
-mdIndex, csvIndex, othersIndex, folderIndex, folderTree = N2Omodule.ObsIndex(ObsidianPaths)
- 
+mdIndex, csvIndex, othersIndex, folderIndex, folderTree = N2Omodule.ObsIndex(
+    ObsidianPaths
+)
+
 
 # Rename the .csv files to .md files for the conversion
 for i in csvIndex:
-    ObsidianPaths[i] = Path(str(ObsidianPaths[i])[0:-3]+"md")
+    ObsidianPaths[i] = Path(str(ObsidianPaths[i])[0:-3] + "md")
 
 
 ## Create a temporary directory to work with
@@ -76,88 +88,77 @@ for d in tempDirectories:
     makedirs(d, exist_ok=True)
 
 
-
-
-
-
 # Process all CSV files
 for n in csvIndex:
-    
     # Access the original CSV file
     with notionsData.open(NotionPathRaw[n], "r") as csvFile:
-         
         # Convert CSV content into Obsidian Internal Links
         mdTitle = N2Omodule.N2Ocsv(csvFile)
 
         ## Make temp destination file path
         newfilepath = tempPath / ObsidianPaths[n]
-        
+
         # Check if file exists, append if true
         if path.exists(newfilepath):
-            append_write = 'a' # append if already exists
+            append_write = "a"  # append if already exists
         else:
-            append_write = 'w' # make a new file if not
-        
+            append_write = "w"  # make a new file if not
+
         # Save CSV internal links as new .md file
-        with open(newfilepath, append_write, encoding='utf-8') as tempFile:
+        with open(newfilepath, append_write, encoding="utf-8") as tempFile:
             [print(line.rstrip(), file=tempFile) for line in mdTitle]
 
 
 num_link = [0, 0, 0, 0]
 # Process all MD files
 for n in mdIndex:
-    
     # Access the original MD file
     with notionsData.open(NotionPathRaw[n], "r") as mdFile:
-        
         # Find and convert Internal Links to Obsidian style
         mdContent, cnt = N2Omodule.N2Omd(mdFile)
-        num_link = [cnt[i]+num_link[i] for i in range(len(num_link))]
-        
+        num_link = [cnt[i] + num_link[i] for i in range(len(num_link))]
+
         # Exported md file include header in first line
         # '# title of file'
         # Get full file name by first line of exported md file instead file name ObsidianPaths[n]
         ## Make temp destination file path
-        new_file_name = mdContent[0].replace('# ', '') + '.md'
+        new_file_name = mdContent[0].replace("# ", "") + ".md"
         new_file_name = regexForbitCharacter.sub("", new_file_name)
         newfilepath = tempPath / path.dirname(ObsidianPaths[n]) / new_file_name
-        
+
         # Check if file exists, append if true
         if path.exists(newfilepath):
-            append_write = 'a' # append if already exists
+            append_write = "a"  # append if already exists
         else:
-            append_write = 'w' # make a new file if not
-        
-        # Save modified content as new .md file
-        with open(newfilepath, append_write, encoding='utf-8') as tempFile:
-            [print(line.rstrip(), file=tempFile) for line in mdContent]
+            append_write = "w"  # make a new file if not
 
-
+        # Save modified content as new .md file except line 1 (#title)
+        with open(newfilepath, append_write, encoding="utf-8") as tempFile:
+            [print(line.rstrip(), file=tempFile) for line in mdContent[1:]]
 
 
 #### Process all attachment files using othersIndex ####
 for n in othersIndex:
-    
     # Move the file from NotionPathRaw[n] in zip to newfilepath = tempPath / ObsidianPaths[n]
     newfilepath = tempPath / ObsidianPaths[n]
-    
+
     # Manage chance of attachments being corrupt. Save a file listing bad files
     try:
         ## if no issue, copy the file
         with notionsData.open(NotionPathRaw[n]) as zf:
-            with open(newfilepath, 'wb') as f:
+            with open(newfilepath, "wb") as f:
                 copyfileobj(zf, f)
     except:
         ## If there's issue, List bad files in a log file
-        with open(tempPath / 'ProblemFiles.md', 'a+', encoding='utf-8') as e:
-            if path.getsize(tempPath / 'ProblemFiles.md') == 0:
-                print('# List of corrupt files from', NotionZip, file=e)
-                print('', file=e)
-            print('  !!File Exception!!',ObsidianPaths[n])
+        with open(tempPath / "ProblemFiles.md", "a+", encoding="utf-8") as e:
+            if path.getsize(tempPath / "ProblemFiles.md") == 0:
+                print("# List of corrupt files from", NotionZip, file=e)
+                print("", file=e)
+            print("  !!File Exception!!", ObsidianPaths[n])
             print(NotionPathRaw[n], file=e)
-            print('', file=e)
+            print("", file=e)
 
-    
+
 print(f"\nTotal converted links:")
 print(f"    - Internal links: {num_link[0]}")
 print(f"    - Embedded links: {num_link[1]}")
@@ -165,11 +166,8 @@ print(f"    - Blank links   : {num_link[2]}")
 print(f"    - Number tags   : {num_link[3]}")
 
 
-# Save temporary file collection to new zip
-make_archive( NotionZip.parent / (NotionZip.name[:-4]+'-ObsidianReady'), 'zip', tempPath)
-
-
-
+make_archive(archiveName, "zip", tempPath)
+print(f"Converted files saved to {archiveName}.zip")
 
 # Close out!
 notionsData.close()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# About this Fork
+While running the script by visualcurrent, I have noticed that the UID was not removed from the files and folders automatically. Arozx has fixed this issue in his fork, however it was not compatible with macOS as the paths were preconfigured. This is why I have removed the preconfiguration, so the user can use the path of choice.
+Also, the headings were doubled as the first line also contained the heading with a "#", which I did not like. This is why I have excluded the first line in this script.
+
 # Notion-2-Obsidian
 
 For those considering switching from [Notion](https://www.notion.so/) to [Obsidian](https://obsidian.md/), here is a Python 3 script that converts your Notion export into an Obsidian friendly format. 
@@ -25,13 +29,6 @@ All of this is remedied by this script. Note however, that Notion comments do NO
 
 If you're interested, the full sequence of modifications needed to make your Notion export compatible with Obsidian can be found in the write-up found in the [Methodology.md](METHODOLOGY.md) file in this git.
 
-# Supporting the Work
-
-I’m happy to offer you this script and the conversion methodology. If you're able and inclined, a donation for the convenience and time savings would be genuinely appreciated. There's a couple donation links at the bottom of this page.
-
-I estimate that anyone using the [Methodology.md](METHODOLOGY.md) can convert their Notion export in a day or less of work. Without this guide, it would likely take several days of troubleshooting. If you’re a confident programmer, it may take you just a couple hours with the guide. I encourage everyone to go through the process. It is satisfying.
-
-However, if your time is worth more spent elsewhere. Feel free to use the code and switch to Obsidian in mere seconds! 
 
 # Export Your Full Notion Database
 If you haven't already, you'll need to export your content from Notion.
@@ -62,11 +59,3 @@ Time to import everything into Obsidian
 4.  Use the Select Folder window to navigate to the directory with your newly converted files
   
 Enjoy the shift to Obsidian!
-
-# Donation Links
-If the instructions or code have been useful for you, please consider the time you've saved and treat me to half a lunch or so :)  My hole-in-the-bucket Covid-19 era income would greatly appreciate it.
-
-Here are some donation links for me:
-* PayPal: https://www.paypal.me/GabrielKrause
-* Venmo: @Gabriel-Krause
-* Etherium: 0xeAE10E05427845aE816E61605eCC779A2d5e59A4


### PR DESCRIPTION
While running the script by visualcurrent, I have noticed that the UID was not removed from the files and folders automatically. Arozx has fixed this issue in his fork, however it was not compatible with macOS as the paths were preconfigured. This is why I have removed the preconfiguration, so the user can use the path of choice. Also, the headings were doubled as the first line also contained the heading with a "#", which I did not like. This is why I have excluded the first line in this script.